### PR TITLE
docs: add English Adopt chapters 1 and 2

### DIFF
--- a/docs/en/adopt/chapter1/index.md
+++ b/docs/en/adopt/chapter1/index.md
@@ -1,3 +1,415 @@
 # Chapter 1: Quick Start with OpenClaw
 
-> 🚧 Content under development
+This chapter walks you through installing OpenClaw, from preparing your environment to running the configuration wizard — all in under 10 minutes.
+
+## 1. System Requirements
+
+- **Operating System**: macOS, Linux, or Windows (WSL2 recommended)
+- **Node.js**: Version 22 or higher
+- **Memory**: At least 1GB, 4GB recommended
+- **Port**: 18789 must be available
+
+<details>
+<summary>Windows Users: What is WSL2 and how to install it?</summary>
+
+WSL2 (Windows Subsystem for Linux 2) lets you run a full Linux environment on Windows. Many development tools work better under Linux. **If you prefer not to set this up, you can use PowerShell directly and skip this step.**
+
+**Installation steps** (requires Windows 10 2004 or later, or Windows 11):
+
+1. Open PowerShell as Administrator (right-click Start Menu → "Terminal (Admin)" or "PowerShell (Admin)")
+2. Run the following command to install WSL2 and Ubuntu in one step:
+
+```powershell
+wsl --install
+```
+
+3. **Restart your computer** after installation
+4. After restarting, an Ubuntu window will pop up automatically — follow the prompts to set up a username and password
+5. Once set up, you have a Linux terminal environment
+
+You can open the WSL2 terminal anytime by searching "Ubuntu" in the Start Menu. All `bash` commands in this tutorial can be run in this terminal.
+
+> **Tip**: If `wsl --install` fails, you may need to first enable "Windows Subsystem for Linux" and "Virtual Machine Platform" in "Control Panel → Programs → Turn Windows features on or off", then restart and try again.
+
+</details>
+
+Check your Node.js version:
+
+```bash
+node --version
+```
+
+If the version is below 22, you need to upgrade Node.js first.
+
+> **What is a Terminal?**
+>
+> Many operations in this tutorial require typing commands in a "terminal". A terminal is a text-based interface where you type commands for your computer to execute. Here's how to open one on different operating systems:
+>
+> - **Windows**: Press `Win + X` and select "Terminal" or "PowerShell"; or search "PowerShell" in the Start Menu
+> - **macOS**: Press `Cmd + Space`, search for "Terminal" and open it; or find it in "Applications → Utilities"
+> - **Linux**: Press `Ctrl + Alt + T`; or search "Terminal" in your application menu
+>
+> You'll see a window (dark or light) with a blinking cursor — that's your terminal. All commands in `bash` code blocks throughout this tutorial should be entered here.
+
+## 2. Installing Node.js
+
+### Windows Users
+
+**Option 1: One-click install script (recommended)**
+
+Open PowerShell (as Administrator) and run:
+
+```powershell
+iwr -useb https://openclaw.ai/install.ps1 | iex
+```
+
+This script automatically installs Node.js and OpenClaw. If you encounter a permission error, first run:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+**Option 2: Manual installation**
+
+1. Download nvm-windows: Visit [github.com/coreybutler/nvm-windows/releases](https://github.com/coreybutler/nvm-windows/releases) and download `nvm-setup.exe`
+2. After installation, reopen PowerShell (as Administrator)
+3. Install Node.js 22:
+
+```powershell
+nvm install 22
+nvm use 22
+```
+
+### macOS Users
+
+Install using Homebrew:
+
+```bash
+brew install node@22
+```
+
+### Linux Users
+
+Install using nvm (recommended):
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+source ~/.bashrc
+nvm install 22
+nvm use 22
+```
+
+## 3. Installing OpenClaw
+
+Install the OpenClaw CLI globally:
+
+```bash
+npm install -g openclaw@latest
+```
+
+Verify the installation:
+
+```bash
+openclaw --version
+```
+
+If you see a version number, the installation was successful.
+
+## 4. Running the Configuration Wizard
+
+After installation, run the configuration wizard:
+
+```bash
+openclaw onboard --install-daemon
+```
+
+This command starts an interactive setup wizard and installs the background daemon.
+
+### 4.1 Choosing a Model Provider
+
+The wizard first asks which AI model you want to use.
+
+**For users in China, SiliconFlow is strongly recommended** — new users get **16 CNY in free credits**, enough to complete all exercises in this tutorial, with no international credit card required.
+
+| Recommended Path | Best For | Cost |
+|-----------------|----------|------|
+| **SiliconFlow** | Users in China (first choice) | 16 CNY free for new users |
+| DeepSeek | Users in China (alternative) | Pay-as-you-go via Alipay |
+| Qwen (Tongyi Qianwen) | Users in China (alternative) | Alibaba Cloud ecosystem, enterprise support |
+| Kimi / StepFun / MiniMax | Users in China (other options) | Alipay supported |
+
+**For international users**, you can use any OpenAI-compatible API provider, or configure a custom endpoint. Popular options include OpenRouter (access multiple models with one key) and direct provider APIs.
+
+### 4.2 Getting an API Key: SiliconFlow Example
+
+> If you already have an API Key from another provider, skip to section 4.3.
+
+**Step 1: Create an account**
+
+1. Visit [SiliconFlow](https://cloud.siliconflow.cn)
+2. Click "Sign Up" in the top right corner — register with your phone number (WeChat login also supported)
+3. After registration, you automatically receive **16 CNY in free credits**
+
+**Step 2: Create an API key**
+
+1. After logging in, go to the [Console](https://cloud.siliconflow.cn/account/ak)
+2. Select "API Keys" from the left menu
+3. Click "Create New API Key"
+4. Copy the generated key (starts with `sk-`)
+
+> **Important**: The API key is only shown once. Copy and save it immediately in a secure location. If lost, you'll need to create a new one.
+
+**Step 3: Top up (optional)**
+
+After the free credits are used up, top up in the console's "Billing Center" — Alipay and WeChat Pay are supported.
+
+> **Cost reference**: Using the DeepSeek V3 model, 16 CNY covers approximately 800–1500 conversations. Light daily usage costs about 10–30 CNY per month.
+
+<details>
+<summary>API Key setup for other providers</summary>
+
+- **DeepSeek**: Visit https://platform.deepseek.com — register and create a key in the console, supports Alipay top-up
+- **Qwen (Tongyi Qianwen)**: Visit https://dashscope.console.aliyun.com — under Alibaba Cloud, strong Chinese language support, enterprise-grade
+- **Kimi (Moonshot)**: Visit https://platform.moonshot.cn — domestic team, strong Chinese comprehension
+- **StepFun**: Visit https://platform.stepfun.com — strong multimodal capabilities, supports long context
+- **MiniMax**: Visit https://platform.minimaxi.com — supports voice and multimodal
+- **OpenRouter**: Visit https://openrouter.ai — one key for accessing multiple models
+
+</details>
+
+### 4.3 Configuring in the Wizard
+
+Select your provider in the wizard and enter your API Key:
+
+```
+◇  Model/auth provider
+│  ○ DeepSeek
+│  ○ Kimi (Moonshot)
+│  ○ OpenRouter
+│  ● Custom (custom API endpoint) ← Select this for SiliconFlow
+```
+
+After selecting `Custom`, enter the following when prompted:
+
+- **API Base URL**: `https://api.siliconflow.cn/v1`
+- **API Key**: Paste the key you copied earlier
+- **Default Model**: `deepseek-ai/DeepSeek-V3` (recommended)
+
+You can also skip the wizard and configure manually via the command line:
+
+```bash
+openclaw config set llm.provider "siliconflow"
+openclaw config set llm.baseUrl "https://api.siliconflow.cn/v1"
+openclaw config set llm.apiKey "sk-xxxxx"
+openclaw config set llm.default "deepseek-ai/DeepSeek-V3"
+```
+
+### 4.4 Configuring Chat Channels (Optional)
+
+The wizard will ask whether to configure Slack, Telegram, or other chat channels. If you don't need them yet, skip this step — you can add channels later with `openclaw configure`.
+
+### 4.5 Configuring Skills (Optional)
+
+The wizard displays a list of available skills and asks whether to install them. We recommend skipping this for now and installing skills after you're familiar with the basics.
+
+Once configuration is complete, the wizard automatically starts the Gateway daemon.
+
+## 5. Verifying the Installation
+
+Check the Gateway status:
+
+```bash
+openclaw status
+```
+
+If you see `Gateway service: running`, the installation was successful.
+
+Open the Web dashboard:
+
+```bash
+openclaw dashboard
+```
+
+Your browser will automatically open `http://localhost:18789`, where you can chat with OpenClaw.
+
+## 6. Your First Conversation
+
+Try the following prompt in the dashboard:
+
+```
+Create a file called hello.txt with today's date and "Hello from OpenClaw!"
+```
+
+If OpenClaw successfully creates the file and confirms completion, everything is working. Try something more interesting:
+
+```
+Write a number guessing game in Python, save it as game.py and run it
+```
+
+> **Tip**: If OpenClaw only gives suggestions instead of executing commands, see the "Tools Profile" issue in the FAQ at the end of this chapter.
+
+## 7. Cost and Budget Control
+
+SiliconFlow's 16 CNY free credits are enough to complete the first few chapters. Daily usage costs depend on your call frequency and model choice.
+
+**Cost-saving tips**:
+- Use smaller models (e.g., Qwen2.5-7B) for simple tasks, and larger models (e.g., DeepSeek V3) only for complex tasks
+- Chapter 8 covers multi-model routing and cost optimization strategies in detail
+
+<details>
+<summary>Advanced: Coding Plan subscriptions (for heavy users)</summary>
+
+If you use OpenClaw heavily every day, pay-per-token pricing may not be economical. Some platforms offer fixed monthly Coding Plan subscriptions (e.g., Alibaba Cloud Bailian, Zhipu GLM) that provide access to coding-optimized models at a flat rate.
+
+To configure: Run `openclaw configure`, select a Coding Plan provider in the wizard, and enter your subscription API Key. You can also add it manually in the Web dashboard under "Settings" → "All Settings".
+
+> For most users, SiliconFlow's pay-as-you-go pricing is already cost-effective enough — no need for a Coding Plan subscription.
+
+</details>
+
+## 8. Common Commands
+
+### Basic Commands
+
+```bash
+# Check overall status
+openclaw status
+
+# Deep health check
+openclaw status --deep
+
+# System diagnostics and repair
+openclaw doctor
+
+# Check version
+openclaw --version
+
+# View help
+openclaw --help
+```
+
+### Gateway Management
+
+```bash
+# Check Gateway status
+openclaw gateway status
+
+# Start Gateway
+openclaw gateway start
+
+# Stop Gateway
+openclaw gateway stop
+
+# Restart Gateway (required after config changes)
+openclaw gateway restart
+
+# Run in foreground with logs (for debugging)
+openclaw gateway run --verbose
+```
+
+### Model Management
+
+```bash
+# List available models
+openclaw models list
+
+# Check model status
+openclaw models status
+
+# Set default model
+openclaw models set <provider/model>
+
+# Check API authentication
+openclaw models auth
+```
+
+### Channel Management
+
+```bash
+# List all channels
+openclaw channels list
+
+# Check channel connection status
+openclaw channels status
+
+# Add a new channel
+openclaw channels add
+
+# Log in to a channel (e.g., scan QR code for WhatsApp)
+openclaw channels login
+
+# Log out of a channel
+openclaw channels logout
+```
+
+### Logs and Debugging
+
+```bash
+# Follow logs in real time
+openclaw logs --follow
+
+# View recent logs
+openclaw logs
+```
+
+## 9. FAQ
+
+**Q: OpenClaw only chats but doesn't take action — it gives suggestions instead of executing commands?**
+
+A: This is the most common issue since version 2026.3.2, caused by the Tools Profile being set to "messaging". Two ways to fix it:
+
+Method 1: Command line fix (recommended)
+
+```bash
+# Check current profile
+openclaw config get tools
+
+# If it's not "full", switch to full
+openclaw config set tools.profile full
+
+# Restart the gateway
+openclaw gateway restart
+```
+
+Method 2: Web UI fix
+
+1. Visit http://localhost:18789 (default local port)
+2. Click "Settings" or "Agents" in the sidebar
+3. Find the relevant Agent, click "tools" next to it
+4. Select the "Full" option
+5. Save and restart
+
+Or edit the config file directly and change the tools section to:
+
+```json
+"tools": {
+  "profile": "full"
+}
+```
+
+**Q: Getting "API key not found" — what should I do?**
+
+A: Edit the config file `openclaw.json` and make sure the API key is configured correctly. For example, using SiliconFlow:
+
+```json
+{
+  "llm": {
+    "provider": "siliconflow",
+    "baseUrl": "https://api.siliconflow.cn/v1",
+    "apiKey": "sk-xxxxx",
+    "default": "deepseek-ai/DeepSeek-V3"
+  }
+}
+```
+
+**Q: Can't access the web dashboard?**
+
+A: Check your firewall settings and make sure port 18789 is not in use by another application. You can change the port number in the config file.
+
+**Q: Commands fail to execute?**
+
+A: Make sure OpenClaw has sufficient file system permissions. Some operations may require explicit authorization.
+
+---
+
+**Next**: [Chapter 2: Understanding OpenClaw](/en/adopt/chapter2/)

--- a/docs/en/adopt/chapter2/index.md
+++ b/docs/en/adopt/chapter2/index.md
@@ -1,3 +1,199 @@
 # Chapter 2: Understanding OpenClaw
 
-> 🚧 Content under development
+Before diving deeper into OpenClaw's features, it's worth understanding what it really is, how it works under the hood, and how it differs from tools like ChatGPT. This chapter covers the architecture, core concepts, and trade-offs you should be aware of.
+
+## 1. What is OpenClaw, Really?
+
+### 1.1 More Than a Chatbot
+
+If you've used ChatGPT, you're probably used to interactions like this:
+
+```
+You: Help me organize the emails in my inbox
+ChatGPT: I can give you some tips on organizing emails...
+```
+
+With OpenClaw, the interaction looks like this:
+
+```
+You: Help me organize the emails in my inbox
+OpenClaw: [Connecting to Gmail API...]
+          [Reading 127 unread emails...]
+          [Classifying by topic, generating summary...]
+          Done! Emails sorted into 5 categories, 3 important emails flagged.
+```
+
+**The core difference**: ChatGPT is an advisor. OpenClaw is an executor.
+
+OpenClaw isn't just a chatbot — it's more like a 24/7 digital assistant. You can have it set reminders ("Remind me to check my calendar every morning at 8am"), reply to messages ("Answer the technical questions on Slack for me"), or handle routine tasks ("Book the meeting room for 3pm tomorrow"). Its core capabilities include local file read/write, browser automation, code generation and execution, multi-platform messaging, and system monitoring and operations.
+
+According to [Wikipedia](https://en.wikipedia.org/wiki/OpenClaw), OpenClaw is a free and open-source autonomous AI agent project that executes tasks through large language models, using messaging platforms (WhatsApp, Telegram, Discord, Slack, etc.) as its primary user interface. It's designed as a "digital employee" that handles real work, not just provides advice.
+
+### 1.2 An Autonomous AI Agent
+
+OpenClaw is an open-source autonomous AI agent execution engine, created by developer Peter Steinberger. Its key characteristics include:
+
+- **Local execution**: Runs on your own device — your data stays under your control
+- **Real execution**: Doesn't just generate code — it runs, verifies, and fixes it
+- **Autonomous decision-making**: Breaks down tasks, selects tools, self-checks, and iterates
+- **Multi-platform integration**: Control it from anywhere via Telegram, Discord, Slack, and more
+
+This means OpenClaw doesn't just understand your requirements — it actually gets things done on your computer. It can manipulate the file system, execute commands, control browsers, call APIs, and deliver results. This is something traditional conversational AI simply cannot do.
+
+### 1.3 The Journey: From Clawdbot to OpenClaw
+
+The project's history is worth knowing:
+
+- **2025.11**: First released under the name Clawdbot
+- **Brief rename**: Changed to Moltbot due to Anthropic trademark concerns
+- **2026.01**: Officially named OpenClaw
+- **2026.02**: Went viral, became the fastest-growing project in GitHub history
+- **2026.02.14**: Creator announced joining OpenAI; project transferred to an open-source foundation
+
+This timeline itself signals a trend: 2026 is the year of the AI Agent.
+
+## 2. Why Does OpenClaw Matter?
+
+### 2.1 From "Smart Planning" to "Local Execution"
+
+The limitations of traditional AI assistants are clear. They excel at information retrieval and code generation, but they can't perform real tasks like file operations, command execution, or browser control. You can ask ChatGPT to write a Python script for organizing files, but then you still need to copy the code, save it, open a terminal, and run it yourself. If it errors out, you have to copy the error message back and ask for a revised version.
+
+OpenClaw bridges the gap between "smart planning" and "actual execution". Anthropic's data shows that regular chat consumes 1x tokens, a single agent about 4x, and multi-agent systems up to 15x. This isn't just a cost increase — it's a capability leap. More reasoning compute translates into results that actually get executed.
+
+### 2.2 Data Sovereignty: Your Data, Your Rules
+
+Unlike SaaS AI assistants, OpenClaw's local-first design means sensitive data never leaves your device. You can choose to use cloud APIs (like Claude or GPT) or fully local models (via Ollama). All "memory" is stored in local Markdown files that are readable, editable, and portable.
+
+This is especially important for enterprise scenarios. ByteDance's Volcano Engine, Alibaba Cloud, Tencent Cloud, and other major Chinese cloud providers quickly offered OpenClaw hosting services, precisely because of this "controllable AI execution power". Enterprises can deploy OpenClaw on their own private clouds, ensuring that code, documents, and customer data never leak to external services.
+
+### 2.3 The Skills Ecosystem: Extensible Capabilities
+
+OpenClaw has a "Skills" ecosystem similar to npm or browser extensions. Each skill is essentially a bundle of tool definitions (telling the agent what it can do), configuration templates (like API keys), and prompt instructions (how to best use the tools).
+
+You can install skills with a simple command: install a weather skill and OpenClaw can answer "Will it rain tomorrow?"; install Gmail integration and it can manage your email; install a code review skill and it can automatically review PRs. The more skills the community contributes, the more OpenClaw can do.
+
+## 3. How Does OpenClaw Work?
+
+### 3.1 Core Architecture
+
+OpenClaw's architecture has four layers:
+
+1. **Message Channels**: The top layer supports multiple entry points — Telegram, Discord, Slack, CLI, and more. You can send commands from anywhere.
+
+2. **Intelligent Decision Core (Brain)**: Handles LLM reasoning, task decomposition and planning, and tool selection and invocation.
+
+3. **Skills Plugin System**: Provides capabilities like file operations, shell commands, browser control, and API integrations.
+
+4. **Dual-Mode Memory System**: Includes SOUL.md (identity and behavior instructions), MEMORY.md (long-term memory), and conversation history (short-term context).
+
+This layered design makes OpenClaw both flexible and controllable. You can customize the agent's personality and behavioral guidelines by editing SOUL.md, let it remember your preferences and project context via MEMORY.md, and extend its capabilities by installing different skills.
+
+### 3.2 A Typical Execution Flow
+
+Take "Generate a weekly report and send it to the team" as an example:
+
+After receiving the request, the agent first **decomposes the task**: read this week's Git commits, call the project management tool API to get task completion status, generate a structured weekly report, and send it via email.
+
+Then it **executes and verifies**: reads the Git log (finds 23 commits), calls the Jira API (gets 5 completed tasks), generates the report in Markdown format, verifies the recipient addresses, and sends the email. Finally, it reports the send status.
+
+Throughout the process, the agent **self-checks**: Does the report include all key information? Does the format match team standards? Was the email sent successfully? If any step fails, it automatically retries or adjusts its strategy. This autonomy, tool-calling ability, and verification loop is what traditional conversational AI cannot achieve.
+
+### 3.3 Key Differences from Traditional AI
+
+The differences between OpenClaw and ChatGPT go deeper than "can it execute commands":
+
+| Aspect | Traditional AI (ChatGPT) | OpenClaw |
+|--------|-------------------------|----------|
+| **Interaction model** | Question-and-answer | Task-driven |
+| **Context management** | Single conversation memory | Persistent long-term memory |
+| **Tool usage** | Simulates or suggests | Actually invokes tools |
+| **Error handling** | User must fix manually | Auto-retries and adjusts |
+| **Runtime** | Cloud service (data sent to provider) | Local or self-hosted (data stays with you) |
+
+The most important difference is the runtime model. ChatGPT is an online service — your data must be sent to OpenAI's servers. OpenClaw can run entirely locally or be self-hosted on your own servers. This means you can use it with sensitive information without worrying about data leaks.
+
+## 4. The Trade-offs: Power and Cost
+
+### 4.1 Multi-Agent Advantages
+
+OpenClaw's multi-agent architecture brings three key advantages:
+
+**Parallel exploration**: When you need competitive analysis, the main agent can dispatch multiple sub-agents to search technical docs, analyze market reports, and scrape pricing info simultaneously, then aggregate results into a comprehensive report. This is much faster than sequential execution.
+
+**Context isolation**: When the main conversation accumulates too many failed attempts, context becomes noisy and the agent's decision quality degrades — it may even repeat paths that already failed. Sub-agents can execute subtasks in a clean context, avoiding "context degradation".
+
+**Reasoning compute scaling**: A single agent is limited by its context window (e.g., 200K tokens). Multiple agents can break through this limit, each with its own context space. The system's total token budget can far exceed any single agent's limit.
+
+### 4.2 Costs to Watch Out For
+
+But the costs are equally real:
+
+**Token costs** jump from 1x to 15x — not trivial. Heavy daily use can lead to high API bills.
+
+**Information transfer loss** is more subtle: each handoff between agents loses some context detail, creating a "telephone game" effect. When the orchestrator passes a task to a sub-agent, the nuances of the original intent may get simplified. When the sub-agent returns results, the contextual clues from its exploration get compressed away.
+
+**Implicit decision chain breakage** is easy to overlook. Every code change carries implicit decision logic that isn't explicitly documented. When multiple agents work in parallel, Sub-agent A might choose a certain data structure while Sub-agent B unknowingly introduces an incompatible dependency. The root cause isn't a code error — it's fragmented decision context.
+
+> **Important**
+> Anthropic's practical experience: "We've seen teams spend months building complex multi-agent architectures, only to find that improving a single agent's prompts achieves the same results."
+
+### 4.3 When to Use Multiple Agents?
+
+The key criterion is **context coupling**:
+
+- **Low coupling** (good for splitting): Code search, information gathering, black-box testing — subtasks are independent and produce standalone results
+- **High coupling** (keep as single agent): Core coding, architecture design, shared state — these tasks need full context for correct decisions
+
+In short: if two subtasks need to share extensive context to each produce correct results, don't split them. If they can be completed independently and only need results merged at the end, splitting makes sense.
+
+## 5. Real-World Applications
+
+### 5.1 Personal Productivity
+
+**Morning briefing system**: Set a daily 7:00 AM trigger — OpenClaw fetches the weather, reads your calendar events, checks important emails, and pushes a summary to your Telegram. You know your day's schedule the moment you wake up.
+
+**Email auto-classification**: OpenClaw periodically scans your Gmail inbox, identifies email types (work, personal, marketing), extracts key information, auto-labels priority, and generates a daily digest. Far more efficient than manual sorting, and nothing important gets missed.
+
+### 5.2 Developer Workflows
+
+**Code review assistant**: Automatically triggered when you submit a PR. It reads the PR diff, checks coding standards, identifies potential bugs, generates review comments, and posts them on the PR. Saves review time and ensures consistency.
+
+**Documentation sync**: When you modify a function signature, OpenClaw can watch for code changes, automatically update API docs, generate usage examples, update the CHANGELOG, and submit a documentation PR. Docs never fall out of sync with code.
+
+### 5.3 Enterprise Applications
+
+**Customer support automation**: OpenClaw connects to Slack, email, ticketing systems, and other channels. It understands customer issues, searches the knowledge base, and generates solutions. If a problem is too complex, it automatically escalates to a human agent with all collected information and preliminary analysis.
+
+**Automated data reports**: Set a weekly Monday 9:00 AM trigger — OpenClaw extracts data from databases, APIs, and logs, generates trend charts for core metrics, performs anomaly detection, proposes optimization suggestions, and sends the report to relevant teams automatically.
+
+## 6. Security Considerations
+
+### 6.1 First-Time Setup
+
+- Start in a test environment — don't run against production data right away
+- Be cautious with file system permissions — OpenClaw can read and write your files
+- Regularly review the agent's operation logs to understand what it's doing
+- Set up manual confirmation for sensitive operations (file deletion, email sending, etc.)
+
+### 6.2 Cost Control
+
+- Set API call limits to prevent runaway costs from agent loops
+- Use caching and local models to reduce costs significantly
+- Monitor token consumption to identify which tasks are most expensive, then optimize accordingly
+
+### 6.3 Learning Approach
+
+- Start with simple tasks (weather queries, file organization) and gradually increase complexity (email management, code review)
+- Understand the fundamentals before creating custom skills — don't try to build complex systems from day one
+
+## 7. What's Next
+
+OpenClaw represents a critical turning point in AI: from conversation to execution, from advice to action. It's not perfect — there are costs, risks, and a learning curve. But it opens a door to AI as a true "digital employee", not just a chat companion.
+
+This tutorial has two parts. The "Adopt" guide helps you get up and running and turn OpenClaw into a daily productivity tool. The "Build" guide takes you through implementing an agent from scratch to deeply understand how it works.
+
+Let's get started.
+
+---
+
+**Next**: [Chapter 3: Mobile Access](/en/adopt/chapter3/)


### PR DESCRIPTION
## Summary
- **Chapter 1 (Quick Start)**: Full English translation of the CN chapter covering installation, configuration wizard, first conversation, common commands, and FAQ
- **Chapter 2 (Understanding OpenClaw)**: Adapted from CN adopt index — covers architecture, how it works vs ChatGPT, multi-agent trade-offs, real-world use cases, and security considerations

Both chapters replace the previous stub content (`🚧 Content under development`).